### PR TITLE
Add mockito extension

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,4 @@
+mdsdToolsEclipsePipeline {  
+	webserverDir = 'thirdparty-library'
+	updateSiteLocation = 'target/repository'
+} 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,5 @@
 mdsdToolsEclipsePipeline {  
 	webserverDir = 'thirdparty-library'
 	updateSiteLocation = 'target/repository'
+    skipCodeQuality = true
 } 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 mdsdToolsEclipsePipeline {  
-	webserverDir = 'thirdparty-library'
-	updateSiteLocation = 'target/repository'
+    webserverDir = 'thirdparty-library'
+    updateSiteLocation = 'target/repository'
     skipCodeQuality = true
 } 

--- a/pom.xml
+++ b/pom.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
 
-	<groupId>tools.mdsd.thirdparty-library</groupId>
-	<artifactId>parent</artifactId>	
-	<version>0.1.0-SNAPSHOT</version>
-	<packaging>pom</packaging>
+  <groupId>tools.mdsd.thirdparty-library</groupId>
+  <artifactId>parent</artifactId>
+  <version>0.1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
 
-	<properties>
-		<com.google.inject.guice.version>4.2.2</com.google.inject.guice.version>
-		<com.google.guava.version>25.1-jre</com.google.guava.version>
-		
-		
-		<license.apache20>							Apache License${line.separator}
+  <properties>
+    <org.mockito.junit.jupiter.version>2.23.0</org.mockito.junit.jupiter.version>
+
+
+    <license.apache20>							Apache License${line.separator}
 					   Version 2.0, January 2004${line.separator}
 					http://www.apache.org/licenses/${line.separator}
 ${line.separator}
@@ -900,52 +900,70 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT${line
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS${line.separator}
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.${line.separator}
 ===============================================================================</license.additions.apache.commons.math3>
+<license.mockito>
+The MIT License${line.separator}
+${line.separator}
+Copyright (c) 2007 Mockito contributors${line.separator}
+${line.separator}
+Permission is hereby granted, free of charge, to any person obtaining a copy${line.separator}
+of this software and associated documentation files (the "Software"), to deal${line.separator}
+in the Software without restriction, including without limitation the rights${line.separator}
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell${line.separator}
+copies of the Software, and to permit persons to whom the Software is${line.separator}
+furnished to do so, subject to the following conditions:${line.separator}
+${line.separator}
+The above copyright notice and this permission notice shall be included in${line.separator}
+all copies or substantial portions of the Software.${line.separator}
+${line.separator}
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR${line.separator}
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,${line.separator}
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE${line.separator}
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER${line.separator}
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,${line.separator}
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN${line.separator}
+THE SOFTWARE.${line.separator}
+</license.mockito>
 		
 	</properties>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.reficio</groupId>
-                <artifactId>p2-maven-plugin</artifactId>
-                <version>1.3.0</version>
-                <executions>
-                    <execution>
-                        <id>default-cli</id>
-						<phase>compile</phase>
-						<goals>
-							<goal>site</goal>
-						</goals>
-                        <configuration>
-							<categoryFileURL>${project.basedir}/category.xml</categoryFileURL>
-							<featureDefinitions>
-								<feature>
-									<id>com.google.inject.guice.feature</id>
-									<version>${com.google.inject.guice.version}</version>
-									<label>Google Guice</label>
-									<providerName>${project.groupId}</providerName>
-									<description>${project.description}</description>
-									<license>${license.apache20}</license>
-									<generateSourceFeature>true</generateSourceFeature>
-									<artifacts>
-										<artifact>
-											<id>com.google.inject:guice:${com.google.inject.guice.version}</id>
-											<transitive>false</transitive>
-											<source>true</source>
-										</artifact>
-										<artifact>
-											<id>com.google.guava:guava:${com.google.guava.version}</id>
-											<transitive>false</transitive>
-											<source>true</source>
-										</artifact>
-									</artifacts>									
-								</feature>
-							</featureDefinitions>									
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.reficio</groupId>
+        <artifactId>p2-maven-plugin</artifactId>
+        <version>1.3.0</version>
+        <executions>
+          <execution>
+            <id>default-cli</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>site</goal>
+            </goals>
+            <configuration>
+              <categoryFileURL>${project.basedir}/category.xml</categoryFileURL>
+              <featureDefinitions>
+                <feature>
+                  <id>org.mockito.junit.jupiter.feature</id>
+                  <version>${org.mockito.junit.jupiter.version}</version>
+                  <label>Mockito JUnit5 Extension</label>
+                  <providerName>${project.groupId}</providerName>
+                  <description>${project.description}</description>
+                  <license>${license.mockito}</license>
+                  <generateSourceFeature>true</generateSourceFeature>
+                  <artifacts>
+                    <artifact>
+                      <id>org.mockito:mockito-junit-jupiter:${org.mockito.junit.jupiter.version}</id>
+                      <transitive>false</transitive>
+                      <source>true</source>
+                    </artifact>
+                  </artifacts>
+                </feature>
+              </featureDefinitions>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>


### PR DESCRIPTION
- Added the Mockito Extension for JUnit 5 (Mockito and Junit are available on Orbit, the extension to unfortunately not); the version was matched to the most recent mockito-core version on Orbit.
- Removed the Guice artifact as it was not working. Currently, we deploy it together with Characteristics until the respective issue is resolved (MDSD-Tools/Characteristics-Modeling#8)
- Added Jenkinsfile to use MDSD.tools CI