### PR TITLE
Override mockito export, as extensions are not compatible otherise

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1005,6 +1005,12 @@ DAMAGE.${line.separator}
                       <id>org.mockito:mockito-core:${org.mockito.version}</id>
                       <transitive>false</transitive>
                       <source>true</source>
+                      <override>true</override>
+                      <instructions>
+                          <Import-Package>net.bytebuddy.*;version="[1.6.0,2.0)</Import-Package>
+                          <Import-Package>*;resolution:=optional</Import-Package>
+                          <Export-Package>*</Export-Package>
+                      </instructions>
                     </artifact>
                     <artifact>
                       <id>org.mockito:mockito-junit-jupiter:${org.mockito.version}</id>


### PR DESCRIPTION
Unfortunately, Mockito provides extensions (i.e. the JUnit 5 extension) which require access to internal packages of Mockito Core. Until there is a proper fix in the Manifest of Mockito, we need to regenerate it, to enable access to its internal packages.